### PR TITLE
BUG: LP events need to start from contract launch to be accurate

### DIFF
--- a/lp_events.py
+++ b/lp_events.py
@@ -29,14 +29,14 @@ if __name__ == "__main__":
 
     v1LiqAdded = {}
     v1LiqRemoved = {}
-    for token in params["lp"]["v1_pools"]["tokens"]:
+    for token in params["lp"]["tokens"]:
         # Get information about specific BridgePool
         # NOTE: We have to start with `bridgeInfo["first_block"]` because
         #       we need to track liquidity deposits/removals that occurred
         #       prior to the first block we track for...
         bridgeInfo = params["across"]["v1"]["mainnet"]["bridge"][token]
         poolAddress = bridgeInfo["address"]
-        firstBlock = bridgeInfo["first_block"]
+        v1FirstBlock = bridgeInfo["first_block"]
         v1EndBlock = params["lp"]["v1_end_block"]
 
         # Create BridgePool object
@@ -44,13 +44,13 @@ if __name__ == "__main__":
 
         # Liquidity Added events
         v1LiqAdded[token] = findEvents(
-            w3, pool.events.LiquidityAdded, firstBlock, v1EndBlock,
+            w3, pool.events.LiquidityAdded, v1FirstBlock, v1EndBlock,
             nBlocks, {}, True
         )
 
         # Liquidity Removed events
         v1LiqRemoved[token] = findEvents(
-            w3, pool.events.LiquidityRemoved, firstBlock, v1EndBlock,
+            w3, pool.events.LiquidityRemoved, v1FirstBlock, v1EndBlock,
             nBlocks, {}, True
         )
 
@@ -63,13 +63,13 @@ if __name__ == "__main__":
     # V2 Liquidity Add/Remove
     # -------------------------------------
     hubInfo = params["across"]["v2"]["mainnet"]["hub"]
-    v2StartBlock = hubInfo["first_block"]
+    v2FirstBlock = hubInfo["first_block"]
     v2EndBlock = params["lp"]["v2_end_block"]
 
     hub = w3.eth.contract(address=hubInfo["address"], abi=getABI("HubPool"))
     addresses = [
         SYMBOL_TO_CHAIN_TO_ADDRESS[token][1]
-        for token in params["lp"]["v2_pools"]["tokens"]
+        for token in params["lp"]["tokens"]
     ]
 
     for event in [hub.events.LiquidityAdded, hub.events.LiquidityRemoved]:
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         eventName = event.event_name
 
         events = findEvents(
-            w3, event, v2StartBlock, v2EndBlock,
+            w3, event, v2FirstBlock, v2EndBlock,
             nBlocks, {"l1Token": addresses}, True
         )
 

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -86,21 +86,18 @@ lp:
   # The number of blocks to request at a time for both v1/v2 liquidity events
   n_blocks: 500_000
 
+  # LPs receive rewards for LPing for these tokens
+  tokens: ["DAI", "USDC", "WBTC", "WETH"]
+
   # v1 start block picked by the v1 launch on 2021-11-08T14:00+00:00
   v1_start_block: 13576190
   # v1 end block picked by the v2 launch on 2022-05-24T14:00+00:00
   v1_end_block: 14836162
 
-  v1_pools:
-    tokens: ["DAI", "USDC", "WBTC", "WETH"]
-
   # v2 launch block picked by the v2 launch on 2022-05-24T14:00+00:00
   v2_start_block: 14836162
   # v2 end block is (for now) arbitrarily specified on 2022-09-07T00:00+00:00
   v2_end_block: 15487072
-
-  v2_pools:
-    tokens: ["DAI", "USDC", "WBTC", "WETH"]
 
   # Shared parameters
   parameters:


### PR DESCRIPTION
This PR makes a few updates to the `lp_events.py` file and to `parameters.yaml`.

The reason these changes are necessary is two-fold:

1. If we start LP events at our specified "start block", we might exclude liquidity that was added/removed prior to that block.
2. The addresses to the Across contracts were stored in the `lp` section and other pieces of the airdrop will need to reference that data so it should be moved to a different section.