### PR TITLE
bug: Fix chain/chain ID bug

### DIFF
--- a/bridgoor_events.py
+++ b/bridgoor_events.py
@@ -82,8 +82,8 @@ if __name__ == "__main__":
         ]
 
         # Get start/end blocks for qualifying
-        v2StartBlock = params["bridgoor"]["v2_start_block"][chain]
-        v2EndBlock = params["bridgoor"]["v2_end_block"][chain]
+        v2StartBlock = params["bridgoor"]["v2_start_block"][chainId]
+        v2EndBlock = params["bridgoor"]["v2_end_block"][chainId]
 
         # Retrieve deposits
         deposits = findEvents(


### PR DESCRIPTION
Worth discussing a little here

In #11 I changed the start/end blocks for `v1` to be specified by their chain ID rather than their chain name. This broke `bridgoor_events.py` (hence this PR)...

I think we should refer to chains by their ID when specifying things like start and end blocks (because it facilitates interacting with on-chain data) but I like being able to do the readable version of `chains: ["mainnet", "optimism", "polygon", "boba", "arbitrum"]` in the parameter file.

I think I'm happy with what's here but would be keen on feedback. An "extreme" version might involve everything to chain names or everything to chain IDs -- I think I'd be opposed to both extremes but I'd be interested in what other people think.