### PR TITLE
bug: Cannot track liquidity positions with liquidity events

### DIFF
--- a/lp_events.py
+++ b/lp_events.py
@@ -70,4 +70,4 @@ if __name__ == "__main__":
         )
 
         with open(f"raw/v2Transfers.json", "w") as f:
-            json.dump(events, f)
+            json.dump(v2Transfers, f)


### PR DESCRIPTION
In #5 I collected raw "liquidity events" (`LiquidityAdded` and `LiquidityRemoved`) but, as @mrice32 pointed out to me early, this is not enough to track an individual's position.

LP tokens can be minted, transferred, and then burned which would result in the original address being credited for having a particular liquidity position indefinitely since the events I was tracking don't acknowledge transfers. Tracking the transfer events for LP tokens solves this problem and is also able to capture both mint (0x0 -> lp) and burn (lp -> 0x0).

This PR updates the `lp_events.py` file to track the `Transfer` events instead of `LiquidityAdded`/`LiquidityRemoved`