### PR TITLE
feat: Add cumulative LP computation

### DIFF
--- a/lp_cumulative.py
+++ b/lp_cumulative.py
@@ -14,10 +14,7 @@ def processTransfers(lpTransfers, version=1):
     """
     out = []
     for token in lpTransfers.keys():
-        if version == 1:
-            decimals = 18
-        elif version == 2:
-            decimals = SYMBOL_TO_DECIMALS[token]
+        decimals = SYMBOL_TO_DECIMALS[token]
 
         for transfer in lpTransfers[token]:
             args = transfer["args"]


### PR DESCRIPTION
Use transfers that were downloaded in `lp_events.py` to keep track of each LP's position.

The result is a DataFrame of the form

```
                                                DAI  ...
         0x6E9E5E7B348c9e705BEA5AEd65B34209199C8494  ... 0x4C34b6d429A4213Dce7148b6B8df249d9bB4C7AE
block                                                ...
14836186                                        0.0  ...                                        0.0
14836321                                        0.0  ...                                        0.0
14836328                                        0.0  ...                                        0.0
14836330                                        0.0  ...                                        0.0
14836351                                        0.0  ...                                        0.0
```

where `block` is on the index, `(token, lp)` is on the columns, and the LP's position at that block is the value.