### PR TITLE
feat: Add 'pre-sleep' to requests

### DIFF
--- a/acx/utils.py
+++ b/acx/utils.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import time
 
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -111,7 +112,7 @@ def createNewSubsetDict(newKey, newValue, d):
     return {x[newKey]: x[newValue] for x in d}
 
 
-def getWithRetries(url, params, nRetries=5, backoffFactor=1.0):
+def getWithRetries(url, params, nRetries=5, backoffFactor=1.0, preSleep=0.0):
     # Create requests session
     session = requests.Session()
 
@@ -126,6 +127,7 @@ def getWithRetries(url, params, nRetries=5, backoffFactor=1.0):
     session.mount("http://", adapter)
     session.mount("https://", adapter)
 
+    time.sleep(preSleep)
     res = session.get(url, params=params)
 
     return res


### PR DESCRIPTION
I occasionally get rate limited by APIs that don't return a non-200 status code -- This adds an argument to `getWithRetries` that allows it to have a "pre-request nap" so that it doesn't get rate limited.