### PR TITLE
bug: multiple deposits in same block produced the wrong result

### DIFF
--- a/lp_cumulative.py
+++ b/lp_cumulative.py
@@ -79,7 +79,8 @@ if __name__ == "__main__":
         data = (
             _df
             .pivot_table(
-                index="block", columns=["symbol", "lp"], values="amount"
+                index="block", columns=["symbol", "lp"], values="amount",
+                aggfunc="sum"
             )
             .fillna(0.0)
             .reindex(columns=newIndex, fill_value=0.0)


### PR DESCRIPTION
A small percentage of users made multiple deposits in the same block and the mean aggregation function in `pd.pivot_table` is `mean` and we want the `sum` instead.