### PR TITLE
update: Change traveler parameters and add section for score calculation

### DIFF
--- a/parameters.yaml
+++ b/parameters.yaml
@@ -115,9 +115,6 @@ bridgoor:
       # The upper bound of volume that counts for score
       ub: 5_000_000
 
-    # min bridge size (in USD) to be included in the airdrop
-    usd_cutoff: 250.0
-
     # Total rewards shared between bridgoors
     total_rewards: 15_000_000
 
@@ -155,6 +152,9 @@ lp:
 # should qualify for the "pre-drop" -- After they qualify, they still need
 # to accomplish their pre-determined Across tasks
 traveler:
+  chains: ["mainnet", "optimism", "polygon", "boba", "arbitrum"]
+  tokens: ["DAI", "USDC", "USDT", "ETH", "WETH", "WBTC"]
+
   n_blocks:
     1: 25_000
     10: 100_000
@@ -165,7 +165,7 @@ traveler:
   # Cbridge
   cbridge:
     chains: ["mainnet", "optimism", "polygon", "arbitrum"]
-    tokens: ["DAI", "USDC", "ETH", "WETH"]
+    tokens: ["DAI", "USDC", "USDT", "ETH", "WETH"]
 
     contract_info:
       1:
@@ -187,8 +187,8 @@ traveler:
 
   # Hop parameters
   hop:
-    chains: ["mainnet", "optimism", "xdai", "polygon", "arbitrum"]
-    tokens: ["DAI", "USDC", "ETH", "WETH"]
+    chains: ["mainnet", "optimism", "gnosis", "polygon", "arbitrum"]
+    tokens: ["DAI", "USDC", "USDT", "ETH", "WETH"]
     first_block:  # 2022-01-01T00:00
       1: 13_916_166
       10: 1_806_122

--- a/wt_hop.py
+++ b/wt_hop.py
@@ -70,15 +70,21 @@ if __name__ == "__main__":
     # Load parameters
     params = parse_config("parameters.yaml")
 
+    # First and last block data
     HOP_FIRST_BLOCK = params["traveler"]["hop"]["first_block"]
     HOP_LAST_BLOCK = params["traveler"]["hop"]["last_block"]
-    SUPPORTED_CHAINS = params["traveler"]["hop"]["chains"]
-    SUPPORTED_CHAIN_IDS = [SHORTNAME_TO_ID[c] for c in SUPPORTED_CHAINS]
+
+    # Chains we collect data from
+    HOP_ORIGIN_CHAINS = params["traveler"]["hop"]["chains"]
     SUPPORTED_TOKENS = params["traveler"]["hop"]["tokens"]
+
+    # Chains that we want transfers to
+    SUPPORTED_CHAINS = params["traveler"]["chains"]
+    SUPPORTED_CHAIN_IDS = [SHORTNAME_TO_ID[c] for c in SUPPORTED_CHAINS]
 
     # Retrieve mainnet transfers separately since they're special
     allDfs = []
-    for chain in SUPPORTED_CHAINS:
+    for chain in HOP_ORIGIN_CHAINS:
         chainId = SHORTNAME_TO_ID[chain]
         fb = HOP_FIRST_BLOCK[chainId]
         tb = HOP_LAST_BLOCK[chainId]
@@ -87,7 +93,7 @@ if __name__ == "__main__":
         # set the number of pages to 999 as a magic number because we
         # know that no chain has more than 999,000 transfers
         transfers = retrieveTransfers(
-            chain, fb, tb,
+            "xdai" if chainId == 100 else chain, fb, tb,
             SUPPORTED_CHAIN_IDS, SUPPORTED_TOKENS,
             npages=999, verbose=True
         )

--- a/wt_synapse.py
+++ b/wt_synapse.py
@@ -79,8 +79,8 @@ if __name__ == "__main__":
     params = parse_config("parameters.yaml")
 
     # Chains/Tokens to support
-    SUPPORTED_CHAINS = params["traveler"]["cbridge"]["chains"]
-    SUPPORTED_TOKENS = params["traveler"]["cbridge"]["tokens"]
+    SUPPORTED_CHAINS = params["traveler"]["synapse"]["chains"]
+    SUPPORTED_TOKENS = params["traveler"]["synapse"]["tokens"]
     contractInfo = params["traveler"]["synapse"]["contract_info"]
 
     synapseInflows = []


### PR DESCRIPTION
This PR updates the traveler parameter file in 4 ways:

1. Somehow I managed to not include the Synapse parameters in the Synapse PR... This adds them back
2. The starting block that we track for each bridge is now set to 2022 -- If a user hasn't bridged since the beginning of 2022 then they probably are not an active bridge traveler
3. Introduce a two sections to be used for calculating the score for each bridge traveler
4. Adds USDT as a token that we use in bridge traveler computation