### PR TITLE
bug: I renamed one of the keys without telling backend

### DIFF
--- a/combine_rewards.py
+++ b/combine_rewards.py
@@ -17,9 +17,9 @@ if lp["lp"].isna().any():
 
 travelers = pd.DataFrame(
     pd.read_json("final/traveler_rewards.json", typ="series"),
-    columns=["traveler"]
+    columns=["bridge-traveler"]
 )
-if travelers["traveler"].isna().any():
+if travelers["bridge-traveler"].isna().any():
     raise ValueError("Missing values in traveler data")
 
 out = (


### PR DESCRIPTION
I renamed the bridge traveler key to `traveler` without letting people know -- This broke backend and this PR fixes the file generated.