### PR TITLE
bug: Ensure that we collect across deposits even after bridgoor ends

### DIFF
--- a/bridgoor_events.py
+++ b/bridgoor_events.py
@@ -81,9 +81,11 @@ if __name__ == "__main__":
             for token in params["bridgoor"]["tokens"]
         ]
 
-        # Get start/end blocks for qualifying
+        # Get start block for qualifying
         v2StartBlock = params["bridgoor"]["v2_start_block"][chainId]
-        v2EndBlock = params["bridgoor"]["v2_end_block"][chainId]
+
+        # Collect data throughout end of BT (we'll need this for traveler)
+        v2EndBlock = params["traveler"]["travel_end_block"][chainId]
 
         # Retrieve deposits
         deposits = findEvents(

--- a/bridgoor_normalize.py
+++ b/bridgoor_normalize.py
@@ -100,6 +100,10 @@ if __name__ == "__main__":
     v1Relays = unpackV1Relays(v1RelaysRaw, v1Disputes)
     v2Deposits = unpackV2Deposits(v2DepositsRaw)
 
+    # Save a history of all Across transactions for convenience
+    allAcross = pd.concat([v1Relays, v2Deposits], axis=0, ignore_index=True)
+    allAcross.to_json("intermediate/allAcrossTransactions.json", orient="records")
+
     # Restrict v1 to only relevant blocks
     v1StartBlock = params["bridgoor"]["v1_start_block"]
     v1EndBlock = params["bridgoor"]["v1_end_block"]
@@ -116,5 +120,6 @@ if __name__ == "__main__":
     v2DepositsKeep = v2Deposits.apply(v2Filter, axis=1)
     v2Deposits = v2Deposits.loc[v2DepositsKeep, :]
 
+    # Only save the bridgoor relevant transactions
     bridgoors = pd.concat([v1Relays, v2Deposits], axis=0, ignore_index=True)
-    bridgoors.to_json("intermediate/allBridges.json", orient="records")
+    bridgoors.to_json("intermediate/bridgoorTransactions.json", orient="records")

--- a/bridgoor_rewards.py
+++ b/bridgoor_rewards.py
@@ -50,7 +50,9 @@ if __name__ == "__main__":
     totalACX = params["bridgoor"]["parameters"]["total_rewards"]
 
     # Load bridge data
-    bridgeData = pd.read_json("intermediate/allBridges.json", orient="records")
+    bridgeData = pd.read_json(
+        "intermediate/bridgoorTransactions.json", orient="records"
+    )
     bridgeData["date"] = bridgeData.apply(determineDate, axis=1)
 
     # Load prices data


### PR DESCRIPTION
We originally stopped collecting deposit data at the end of bridgoor -- This was a mistake for a couple reasons:

1. We should have excluded people who used Across between end of bridgoor and before bridge traveler but didn't -- These people became travelers (but it's too late to fix that and it's a relatively limited number of people)
2. We need the after data to compute whether individuals completed bridge traveler

This updates that collection and renames some of the files saved