### PR TITLE
feat: Update rewards->score and use final to compute final rewards

### DIFF
--- a/bt_final.py
+++ b/bt_final.py
@@ -1,0 +1,69 @@
+import json
+
+import pandas as pd
+import web3
+
+from pyaml_env import parse_config
+
+
+if __name__ == "__main__":
+    # Load parameters
+    params = parse_config("parameters.yaml")
+
+    # Reward parameters
+    rewardLb = params["traveler"]["parameters"]["rewards"]["tokens_lb"]
+    rewardUb = params["traveler"]["parameters"]["rewards"]["tokens_ub"]
+    bonusThreshold = params["traveler"]["parameters"]["rewards"]["bonus_threshold"]
+    clipThreshold = params["traveler"]["parameters"]["rewards"]["clip_threshold"]
+
+    # Traveler blocks
+    travelStartBlock = params["traveler"]["travel_start_block"]
+    travelEndBlock = params["traveler"]["travel_end_block"]
+
+    # Qualified travelers
+    travelerRewards = pd.DataFrame(
+        pd.read_json("final/traveler_score.json", typ="series"),
+        columns=["bridge-traveler"]
+    )
+    travelers = travelerRewards.index
+
+    # Read across transactions
+    across = pd.read_json(
+        "intermediate/allAcrossTransactions.json",
+        orient="records"
+    )
+
+    # Filter only transfers that can qualify for BT
+    def filterTravelerTransfers(x):
+        chainId = x["originChain"]
+
+        travelerBlocks = (
+            (x["block"] >= travelStartBlock[chainId]) &
+            (x["block"] <= travelEndBlock[chainId])
+        )
+        travelerQuantity = (
+            (x["symbol"] == "WETH") & (x["amount"] > 0.099) |
+            (x["symbol"] == "USDC") & (x["amount"] > 149.99)
+        )
+        isTraveler = x["sender"] in travelers
+
+        return travelerBlocks & travelerQuantity & isTraveler
+    travelerRelevant = across.apply(filterTravelerTransfers, axis=1)
+    travelerTransfers = across.loc[travelerRelevant, :]
+    completedTravelers = travelerTransfers["sender"].unique()
+    bridgeTravelers = travelerRewards.loc[completedTravelers]
+
+    # Determine how many rewards will be distributed
+    conversionRate = bridgeTravelers.size / travelers.size
+    totalBtReward = (
+        rewardLb +
+        (conversionRate > bonusThreshold)*(rewardUb - rewardLb)
+    )
+
+    # Rescale everyone's share based on participation
+    bridgeTravelers = bridgeTravelers / bridgeTravelers.sum()
+    bridgeTravelers["airdrop"] = (
+        (bridgeTravelers * totalBtReward).clip(0.0, clipThreshold)
+    )
+
+    bridgeTravelers["airdrop"].to_json("final/traveler_rewards.json")

--- a/bt_final.py
+++ b/bt_final.py
@@ -16,6 +16,10 @@ if __name__ == "__main__":
     bonusThreshold = params["traveler"]["parameters"]["rewards"]["bonus_threshold"]
     clipThreshold = params["traveler"]["parameters"]["rewards"]["clip_threshold"]
 
+    # Qualification parameters
+    ethQual = params["traveler"]["parameters"]["qualification"]["eth"]
+    usdcQual = params["traveler"]["parameters"]["qualification"]["usdc"]
+
     # Traveler blocks
     travelStartBlock = params["traveler"]["travel_start_block"]
     travelEndBlock = params["traveler"]["travel_end_block"]
@@ -42,12 +46,14 @@ if __name__ == "__main__":
             (x["block"] <= travelEndBlock[chainId])
         )
         travelerQuantity = (
-            (x["symbol"] == "WETH") & (x["amount"] > 0.099) |
-            (x["symbol"] == "USDC") & (x["amount"] > 149.99)
+            (x["symbol"] == "WETH") & (x["amount"] > ethQual) |
+            (x["symbol"] == "USDC") & (x["amount"] > usdcQual)
         )
         isTraveler = x["sender"] in travelers
 
         return travelerBlocks & travelerQuantity & isTraveler
+
+    # Apply filter
     travelerRelevant = across.apply(filterTravelerTransfers, axis=1)
     travelerTransfers = across.loc[travelerRelevant, :]
     completedTravelers = travelerTransfers["sender"].unique()

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -309,6 +309,10 @@ traveler:
       bonus_threshold: 0.30
       clip_threshold: 25_000
 
+    qualification:
+      eth: 0.099
+      usdc: 149.99
+
 misc:
   # Block data
   block:


### PR DESCRIPTION
This updates two files:

* `bt_rewards`:
  - This now saves a file called `traveler_score.json` which is used in calculating people's pro-rata distribution
  - Bug fixed so that people who began LP'ing after traveler began are not excluded from traveler
* `bt_final`:
  - This file determines who met the bridge criteria and went from a "qualified user" to a "rewarded user"